### PR TITLE
Bugfix: Object.assign changes base reference

### DIFF
--- a/src/markdown-it-incremental-dom.js
+++ b/src/markdown-it-incremental-dom.js
@@ -16,7 +16,8 @@ export default function (md, target, opts = {}) {
     const renderer = mixinTo(this.renderer, mixin)
 
     if (options.incrementalizeDefaultRules) {
-      Object.assign(renderer.rules, incrementalizedRules(incrementalDOM))
+      const overridedRules = Object.assign({}, renderer.rules, incrementalizedRules(incrementalDOM))
+      renderer.rules = overridedRules
     }
 
     return renderer.render(this[method](src, env), this.options, env)


### PR DESCRIPTION
Fixed bug on #7.

`Object.assign` would override default renderer rules. But current implement affects to base reference.

So we made deep copy of rules and re-assign to created renderer.