### PR TITLE
Add license comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Change Log
 
 ### Added
 
+- For browser: Add banner to show license ([#9](https://github.com/yhatt/markdown-it-incremental-dom/pull/9))
+- For browser: Provide uncompressed version ([#9](https://github.com/yhatt/markdown-it-incremental-dom/pull/9))
 - Override markdown-it's default renderer rules by incrementalized functions for better performance ([#7](https://github.com/yhatt/markdown-it-incremental-dom/pull/7))
-- Option argument on initialize that supported `incrementalizeDefaultRules`  ([#7](https://github.com/yhatt/markdown-it-incremental-dom/pull/7))
+- Option argument on initialize that supported `incrementalizeDefaultRules` ([#7](https://github.com/yhatt/markdown-it-incremental-dom/pull/7))
 - Badges on README.md: Coverage (powered by Coveralls), npm version, and LICENSE ([#6](https://github.com/yhatt/markdown-it-incremental-dom/pull/6))
 - [Demo page](https://yhatt.github.io/markdown-it-incremental-dom/) with explaining of key features  ([#3](https://github.com/yhatt/markdown-it-incremental-dom/issue/3))
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Define as `window.markdownitIncrementalDOM`.
 <!DOCTYPE HTML>
 <html>
 <head>
-  <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
   <script src="https://cdn.jsdelivr.net/markdown-it/8.3.1/markdown-it.min.js"></script>
-  <script src="./node_modules/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.js"></script>
+  <script src="./node_modules/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
 </head>
 <body>
   <div id="target"></div>
@@ -58,6 +58,13 @@ Define as `window.markdownitIncrementalDOM`.
 </body>
 </html>
 ```
+
+#### CDN
+
+You can use the recent version through CDN provides by [unpkg.com](https://unpkg.com/).
+
+- **[Compressed (Recommend)](https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js)**
+- [Uncompressed](https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.js)
 
 ## Installation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/superagent/3.5.0/superagent.min.js"></script>
   <script src="https://cdn.jsdelivr.net/markdown-it/8.3.1/markdown-it.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
-  <script src="https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.js"></script>
+  <script src="https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
   <script src="./index.js"></script>
 
   <link rel="stylesheet" href="./index.css" />

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "cross-env NPM_EXECPATH='yarn run' npm-run-all --parallel build:*",
     "build:commonjs": "yarn run clean:lib && babel src --out-dir lib",
-    "build:browser": "yarn run clean:dist && webpack -p",
+    "build:browser": "yarn run clean:dist && webpack",
     "clean": "cross-env NPM_EXECPATH='yarn run' npm-run-all --parallel clean:*",
     "clean:lib": "rimraf lib",
     "clean:dist": "rimraf dist",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,15 +1,35 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import path from 'path'
+import webpack from 'webpack'
 import packageConfig from './package.json'
 
+const banner = `${packageConfig.name} ${packageConfig.version}
+${packageConfig.repository.url}
+
+Includes htmlparser2
+https://github.com/fb55/htmlparser2/
+https://github.com/fb55/htmlparser2/raw/master/LICENSE
+
+@license ${packageConfig.license}
+${packageConfig.repository.url}/raw/master/LICENSE`
+
+const basename = path.basename(packageConfig.browser, '.js')
+
 export default {
-  entry: './entry.js',
+  entry: {
+    [basename]: './entry.js',
+    [`${basename}.min`]: './entry.js',
+  },
   output: {
     path: path.resolve(__dirname, path.dirname(packageConfig.browser)),
-    filename: path.basename(packageConfig.browser),
+    filename: '[name].js',
     libraryTarget: 'umd',
     umdNamedDefine: true,
   },
+  plugins: [
+    new webpack.BannerPlugin(banner),
+    new webpack.optimize.UglifyJsPlugin({ include: /\.min\.js($|\?)/i }),
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
To release as major version (`v1.0.0`), we added license comments to packaged JS for browser.

We included `htmlpacker2` but we cannot find license section at packaged JS. So we added the link URL to htmlpacker2 & its license.

And, we would provide uncompressed version too.