### PR TITLE
Fix prepublishOnly script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ===
 
+[Unreleased]
+---
+
+### Fixed
+
+- Fix double executing pre-publish script in `npm publish` executed by `^npm@4.0.0` ([#11](https://github.com/yhatt/markdown-it-incremental-dom/pull/11))
+
 v1.0.0 - 2017-03-14
 ---
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint --cache .",
     "lint:nocache": "eslint .",
-    "prepublish": "! in-publish && exit 0 || yarn run prepublishOnly",
-    "prepublishOnly": "cross-env NPM_EXECPATH='yarn run' npm-run-all --parallel lint:nocache test:coverage --sequential build",
+    "prepublish": "! in-publish && exit 0 || yarn run prepare:publish",
+    "prepare:publish": "cross-env NPM_EXECPATH='yarn run' npm-run-all --parallel lint:nocache test:coverage --sequential build",
     "test": "cross-env NODE_ENV=test mocha",
     "test:coverage": "cross-env NODE_ENV=test nyc mocha"
   },


### PR DESCRIPTION
We had used `prepublishOnly` to package module certainly and to ready for npm @ 4. In npm @ 3, we keep compatibility by using [in-publish](https://www.npmjs.com/package/in-publish) package. But it means to execute pre-publish task twice in npm @ 4 environment.

To make matters worse, the `prepublishOnly` task would execute after packaging to tarball. So there is no meaning to use prepublishOnly because codes compiled by it would not include in published package.

At first glance, it seems like better just to change from `prepublish` to `prepare`. However there remain the problem of double executing.

We deal it with changing task name from `prepublishOnly` to `prepare:publish` (although npm @ 4 brings deprecated warning).