### PR TITLE
Reduce bundle size of built for browser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,29 @@
 {
-  "presets": [[
-    "env", {
-      "targets": {
-        "node": "4.2"
-      },
-      "useBuiltIns": true
-    }
-  ]],
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "node": "4.2"
+        },
+        "useBuiltIns": true
+      }
+    ]
+  ],
   "plugins": [
     ["transform-object-rest-spread", { "useBuiltIns": true }],
     "add-module-exports"
   ],
   "env": {
     "test": {
-      "presets": ["babel-preset-power-assert"],
-      "plugins": ["istanbul"]
+      "presets": [
+        ["env", { "targets": { "node": "current" }, "useBuiltIns": true }],
+        "babel-preset-power-assert"
+      ],
+      "plugins": [
+        ["transform-object-rest-spread", { "useBuiltIns": true }],
+        "istanbul"
+      ]
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,15 +1,5 @@
 {
-  "presets": [
-    [
-      "env",
-      {
-        "targets": {
-          "node": "4.2"
-        },
-        "useBuiltIns": true
-      }
-    ]
-  ],
+  "presets": [["env", { "targets": { "node": "4.2" }, "useBuiltIns": true }]],
   "plugins": [
     ["transform-object-rest-spread", { "useBuiltIns": true }],
     "add-module-exports"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* Reduce bundle size of built for browser
+
 ## v1.1.1 - 2018-01-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Reduce bundle size of built for browser
+* Reduce bundle size of built for browser ([#22](https://github.com/yhatt/markdown-it-incremental-dom/pull/22))
 
 ## v1.1.1 - 2018-01-06
 

--- a/src/mixins/renderer.js
+++ b/src/mixins/renderer.js
@@ -1,4 +1,4 @@
-import { Parser } from 'htmlparser2'
+import Parser from 'htmlparser2/lib/Parser'
 
 export default function(incrementalDom) {
   const {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -13,6 +13,7 @@ https://github.com/fb55/htmlparser2/raw/master/LICENSE
 ${packageConfig.repository.url}/raw/master/LICENSE`
 
 const basename = path.basename(packageConfig.browser, '.js')
+const browsers = ['> 1%', 'last 2 versions', 'Firefox ESR', 'IE >= 9']
 
 export default {
   entry: {
@@ -37,23 +38,14 @@ export default {
         exclude: /node_modules/,
         loader: 'babel-loader',
         options: {
+          babelrc: false,
           presets: [
             [
               'env',
-              {
-                modules: false,
-                targets: {
-                  browsers: [
-                    '> 1%',
-                    'last 2 versions',
-                    'Firefox ESR',
-                    'ie >= 9',
-                  ],
-                },
-                useBuiltIns: true,
-              },
+              { modules: false, targets: { browsers }, useBuiltIns: true },
             ],
           ],
+          plugins: [['transform-object-rest-spread', { useBuiltIns: true }]],
         },
       },
     ],


### PR DESCRIPTION
This PR reduces the bundle size of built for browser from 187.5KB to 120.4KB (minified).

Incremental DOM supports IE9 and above. Therefore v1.1's browser bundle has included `core-js` polyfill to not only support major browsers but also IE9 and above correctly. However it was made enlarge bundle size drastically.

So we optimized import of htmlparser2 to use [`htmlparser2/lib/Parser.js`](https://github.com/fb55/htmlparser2/blob/master/lib/Parser.js) directly. It could reduce bundled node feature portings. The bundle size would back to the same level as `v1.0.0`.

- `v1.0.0`: 125.1KB
- `v1.1.1`: 187.5KB
- `reduce-bundle-size`: **120.4KB**

### Bundle Analyzer on v1.1.1

![before](https://user-images.githubusercontent.com/3993388/34773526-55cb54a6-f64f-11e7-879e-76f5a6acd4f0.png)

### Improved bundle :sparkles:

![after](https://user-images.githubusercontent.com/3993388/34773532-5be25a74-f64f-11e7-8cc7-7241d2863396.png)

#### NOTE

I have tried these improvements too.

- Use [rollup](https://github.com/rollup/rollup) bundler
- Use [htmlparser2-without-node-native](https://github.com/oyyd/htmlparser2-without-node-native) instead of htmlparser2

But these solutions had not working better. Currently fixes on this PR marks the best improvement of bundle size.