### PR TITLE
Update README.md and demo page to use jsDelivr CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Update README.md and demo page to use jsDelivr CDN
+
 ## v1.1.2 - 2018-01-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Update README.md and demo page to use jsDelivr CDN
+* Update README.md and demo page to use jsDelivr CDN ([#24](https://github.com/yhatt/markdown-it-incremental-dom/pull/24))
 
 ## v1.1.2 - 2018-01-11
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ Define as `window.markdownitIncrementalDOM`.
 
 #### CDN
 
-You can use [the recent version through CDN](https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1) provides by [jsDelivr](https://www.jsdelivr.com/).
+You can use [the recent version through CDN](https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1/dist/markdown-it-incremental-dom.min.js) provides by [jsDelivr](https://www.jsdelivr.com/).
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1"></script>
+<script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1/dist/markdown-it-incremental-dom.min.js"></script>
 ```
+
+* **[Compressed (Recommend)](https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1/dist/markdown-it-incremental-dom.min.js)**
+* [Uncompressed](https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1/dist/markdown-it-incremental-dom.js)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Define as `window.markdownitIncrementalDOM`.
 <html>
 <head>
   <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
-  <script src="https://cdn.jsdelivr.net/markdown-it/8.3.1/markdown-it.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.0/dist/markdown-it.min.js"></script>
   <script src="./node_modules/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
 </head>
 <body>
@@ -63,10 +63,11 @@ Define as `window.markdownitIncrementalDOM`.
 
 #### CDN
 
-You can use the recent version through CDN provides by [unpkg.com](https://unpkg.com/).
+You can use [the recent version through CDN](https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1) provides by [jsDelivr](https://www.jsdelivr.com/).
 
-* **[Compressed (Recommend)](https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js)**
-* [Uncompressed](https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.js)
+```html
+<script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom@1"></script>
+```
 
 ## Installation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,9 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>markdown-it-incremental-dom</title>
 
-  <script src="https://cdn.jsdelivr.net/npm/superagent@3.8.2/superagent.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.0/dist/markdown-it.min.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
+  <script src="https://cdn.jsdelivr.net/combine/npm/superagent@3.8.2/superagent.min.js,npm/markdown-it@8.4.0/dist/markdown-it.min.js,npm/incremental-dom@0.5.1/dist/incremental-dom-min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
   <script src="./index.js"></script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,14 +6,14 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>markdown-it-incremental-dom</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/superagent/3.5.0/superagent.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/markdown-it/8.3.1/markdown-it.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/superagent@3.8.2/superagent.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.0/dist/markdown-it.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
-  <script src="https://unpkg.com/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom"></script>
   <script src="./index.js"></script>
 
   <link rel="stylesheet" href="./index.css" />
-  <link rel="stylesheet" href="https://unpkg.com/github-markdown-css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css">
 </head>
 <body>
   <div class="container">

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,14 +6,14 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>markdown-it-incremental-dom</title>
 
-  <script src="https://cdn.jsdelivr.net/npm/superagent@3.8.2/superagent.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/superagent@3.8.2/superagent.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.0/dist/markdown-it.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/incrementaldom/0.5.1/incremental-dom-min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it-incremental-dom/dist/markdown-it-incremental-dom.min.js"></script>
   <script src="./index.js"></script>
 
   <link rel="stylesheet" href="./index.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) CDN has been updated to provide npm mirror. This PR would update document to recommend it.

The external dependency on demo page is using [jsDelivr's combine endpoint feature](https://www.jsdelivr.com/features#combine).