### PR TITLE
 Fix incrementalized softbreak rule to keep break as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Fix incrementalized softbreak rule to keep break as text
+* Fix incrementalized softbreak rule to keep break as text ([#25](https://github.com/yhatt/markdown-it-incremental-dom/pull/25))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix incrementalized softbreak rule to keep break as text
+
 ### Changed
 
 * Update README.md and demo page to use jsDelivr CDN ([#24](https://github.com/yhatt/markdown-it-incremental-dom/pull/24))

--- a/src/mixins/rules.js
+++ b/src/mixins/rules.js
@@ -25,9 +25,7 @@ export default function(incrementalDom) {
     },
 
     softbreak(tokens, idx, options) {
-      return () => {
-        if (options.breaks) elementVoid('br')
-      }
+      return () => (options.breaks ? elementVoid('br') : text('\n'))
     },
 
     text(tokens, idx) {

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -121,9 +121,11 @@ describe('Renderer', () => {
     const markdown = 'break\ntest'
 
     context('with false', () => {
-      it('ignores breaks', () => {
+      it('keeps breaks as text', () => {
         md({ breaks: false }).idom(markdown)
+
         assert(!document.querySelector('br'))
+        assert(document.querySelector('p').textContent === markdown)
       })
     })
 


### PR DESCRIPTION
When `breaks` option of markdown-it is `false` (by default), the overrided softbreak rule has been ignored and not rendered.

However markdown-it + `element.innerHTML` (or using markdown-it-incremental-dom w/ `incrementalizedDefaultRules: false`) will not ignored softbreak. We often may be able to see it as a space.

![](https://user-images.githubusercontent.com/3993388/34906638-6fb21db6-f8b4-11e7-88e6-007e3a142ea5.gif)

It is also defined in [CommonMark](http://spec.commonmark.org/0.28/#softbreak).

> A regular line break (not in a code span or HTML tag) that is not preceded by two or more spaces or a backslash is parsed as a softbreak. (A softbreak may be rendered in HTML either as a line ending or as a space. The result will be the same in browsers. In the examples here, a line ending will be used.)

This PR would fix the incrementalized softbreak rule to insert break as text when it is disabled.