### PR TITLE
Fix format script to work globstar correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix format script to work globstar correctly ([#26](https://github.com/yhatt/markdown-it-incremental-dom/pull/26))
+
 ## v1.2.0 - 2018-01-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean:lib": "rimraf lib",
     "clean:dist": "rimraf dist",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "format": "prettier **/*.{md,json,css}",
+    "format": "prettier \"**/*.{md,json,css}\"",
     "format:check": "yarn --mutex file run format -l",
     "lint": "eslint .",
     "prepack": "npm-run-all --npm-path yarn --parallel lint test:coverage --sequential build",


### PR DESCRIPTION
In several environments (e.g. macOS's older bash), the `format` script in `package.json` would not apply Prettier to markdown that is put on the root folder. It is caused by bash recognizes globstar as a wildcard.

We could avoid this problem by wrapping file path by double-quotes.