### PR TITLE
Fix build entry and module path for browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Fix format script to work globstar correctly ([#26](https://github.com/yhatt/markdown-it-incremental-dom/pull/26))
+* Fix build entry and module path for browser ([#27](https://github.com/yhatt/markdown-it-incremental-dom/pull/27))
 
 ## v1.2.0 - 2018-01-15
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ require('markdown-it')().use(
 )
 ```
 
-* **`incrementalizeDefaultRules`**: For better performance, this plugin would override a few default renderer rules only when you calls injected methods. If the other plugins that override default rules have occured any problem, You can disable overriding by setting `false`. _(`true` by default)_
+* **`incrementalizeDefaultRules`**: For better performance, this plugin would override a few default renderer rules only when you calls injected methods. If the other plugins that override default rules have occurred any problem, You can disable overriding by setting `false`. _(`true` by default)_
 
 ### Rendering methods
 

--- a/entry.js
+++ b/entry.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/prefer-default-export */
 import markdownitIncrementalDOM from './src/markdown-it-incremental-dom'
 
 export { markdownitIncrementalDOM }
+export default markdownitIncrementalDOM

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.2.0",
   "description": "markdown-it renderer plugin by using Incremental DOM.",
   "main": "lib/markdown-it-incremental-dom.js",
-  "browser": "dist/markdown-it-incremental-dom.js",
   "engines": {
     "node": ">=4.2.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ https://github.com/fb55/htmlparser2/raw/master/LICENSE
 @license ${packageConfig.license}
 ${packageConfig.repository.url}/raw/master/LICENSE`
 
-const basename = path.basename(packageConfig.browser, '.js')
+const basename = path.basename(packageConfig.main, '.js')
 const browsers = ['> 1%', 'last 2 versions', 'Firefox ESR', 'IE >= 9']
 
 exports.default = {
@@ -22,7 +22,7 @@ exports.default = {
     [`${basename}.min`]: './entry.js',
   },
   output: {
-    path: path.resolve(__dirname, path.dirname(packageConfig.browser)),
+    path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
     libraryTarget: 'umd',
     umdNamedDefine: true,


### PR DESCRIPTION
We have made 2 sad mistakes. 😇 

First: This plugin could never used with any bundler for browser (Browserify, webpack etc). `require('markdown-it-incremental-dom')` would return `undefined`. Who did disable eslint rule of `prefer-default-export`? It's me 🙃 

Second: Removed `browser` field in package.json. The bundler for browser respects this field but JS is already bundled. We should provide ES5 module by `main` field.

Of course we would be continue providing build for browser. (`dist/markdown-it-incremental-dom[.min].js`)