### PR TITLE
Define IncrementalDOMRenderer as getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Define `IncrementalDOMRenderer` as public getter ([#28](https://github.com/yhatt/markdown-it-incremental-dom/pull/28))
+
 ### Fixed
 
 * Fix format script to work globstar correctly ([#26](https://github.com/yhatt/markdown-it-incremental-dom/pull/26))

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ require('markdown-it')().use(
 
 ### Rendering methods
 
-#### `MarkdownIt.renderToIncrementalDOM(src[, env]) => Function`
+#### `MarkdownIt.renderToIncrementalDOM(src[, env])` => `Function`
 
 Similar to [`MarkdownIt.render(src[, env])`](https://markdown-it.github.io/markdown-it/#MarkdownIt.render) but _it returns a function for Incremental DOM_. It means doesn't render Markdown immediately.
 
@@ -136,9 +136,31 @@ const func = md.renderToIncrementalDOM('# Hello, Incremental DOM!')
 IncrementalDOM.patch(node, func)
 ```
 
-#### `MarkdownIt.renderInlineToIncrementalDOM(src[, env]) => Function`
+#### `MarkdownIt.renderInlineToIncrementalDOM(src[, env])` => `Function`
 
 Similar to `MarkdownIt.renderToIncrementalDOM` but it wraps [`MarkdownIt.renderInline(src[, env])`](https://markdown-it.github.io/markdown-it/#MarkdownIt.renderInline).
+
+### Renderer property
+
+#### _get_ `MarkdownIt.IncrementalDOMRenderer` => [`Renderer`](https://markdown-it.github.io/markdown-it/#Renderer)
+
+Returns [`Renderer`](https://markdown-it.github.io/markdown-it/#Renderer) instance that includes Incremental DOM support.
+
+It will inject Incremental DOM features into the current state of [`MarkdownIt.renderer`](https://markdown-it.github.io/markdown-it/#MarkdownIt.prototype.renderer) at getting this property.
+
+> **_NOTE:_** This property is provided for the expert. Normally you should use `renderToIncrementalDOM()`.
+>
+> But it might be useful if you have to parse Markdown and operate tokens manually.
+>
+> ```javascript
+> const md = new MarkdownIt()
+> const tokens = md.parse('# Hello')
+>
+> // ...You can operate tokens here...
+>
+> const patch = md.IncrementalDOMRenderer.render(tokens, md.options)
+> IncrementalDOM.patch(document.body, patch)
+> ```
 
 ## Development
 

--- a/src/markdown-it-incremental-dom.js
+++ b/src/markdown-it-incremental-dom.js
@@ -6,27 +6,34 @@ export default function(md, target, opts = {}) {
   const incrementalDOM = !target && window ? window.IncrementalDOM : target
   const mixin = renderer(incrementalDOM)
 
-  const render = function(method, src, env) {
-    const extendedRenderer = Object.assign(
-      Object.create(Object.getPrototypeOf(this.renderer)),
-      this.renderer,
-      mixin
-    )
+  Object.defineProperty(md, 'IncrementalDOMRenderer', {
+    get() {
+      const extended = Object.assign(
+        Object.create(Object.getPrototypeOf(this.renderer)),
+        this.renderer,
+        mixin
+      )
 
-    if (options.incrementalizeDefaultRules) {
-      extendedRenderer.rules = {
-        ...extendedRenderer.rules,
-        ...rules(incrementalDOM),
+      if (options.incrementalizeDefaultRules) {
+        extended.rules = { ...extended.rules, ...rules(incrementalDOM) }
       }
-    }
-
-    return extendedRenderer.render(this[method](src, env), this.options, env)
-  }
+      return extended
+    },
+  })
 
   md.renderToIncrementalDOM = function(src, env = {}) {
-    return render.call(this, 'parse', src, env)
+    return this.IncrementalDOMRenderer.render(
+      this.parse(src, env),
+      this.options,
+      env
+    )
   }
+
   md.renderInlineToIncrementalDOM = function(src, env = {}) {
-    return render.call(this, 'parseInline', src, env)
+    return this.IncrementalDOMRenderer.render(
+      this.parseInline(src, env),
+      this.options,
+      env
+    )
   }
 }

--- a/src/markdown-it-incremental-dom.js
+++ b/src/markdown-it-incremental-dom.js
@@ -9,31 +9,22 @@ export default function(md, target, opts = {}) {
   Object.defineProperty(md, 'IncrementalDOMRenderer', {
     get() {
       const extended = Object.assign(
-        Object.create(Object.getPrototypeOf(this.renderer)),
-        this.renderer,
+        Object.create(Object.getPrototypeOf(md.renderer)),
+        md.renderer,
         mixin
       )
 
       if (options.incrementalizeDefaultRules) {
         extended.rules = { ...extended.rules, ...rules(incrementalDOM) }
       }
+
       return extended
     },
   })
 
-  md.renderToIncrementalDOM = function(src, env = {}) {
-    return this.IncrementalDOMRenderer.render(
-      this.parse(src, env),
-      this.options,
-      env
-    )
-  }
+  md.renderToIncrementalDOM = (src, env = {}) =>
+    md.IncrementalDOMRenderer.render(md.parse(src, env), md.options, env)
 
-  md.renderInlineToIncrementalDOM = function(src, env = {}) {
-    return this.IncrementalDOMRenderer.render(
-      this.parseInline(src, env),
-      this.options,
-      env
-    )
-  }
+  md.renderInlineToIncrementalDOM = (src, env = {}) =>
+    md.IncrementalDOMRenderer.render(md.parseInline(src, env), md.options, env)
 }

--- a/test/markdown-it-incremental-dom.js
+++ b/test/markdown-it-incremental-dom.js
@@ -62,6 +62,28 @@ describe('markdown-it-incremental-dom', () => {
     })
   })
 
+  describe('get IncrementalDOMRenderer', () => {
+    it('returns IncrementalDOM renderer that is injected into current state', () => {
+      const instance = md()
+      const { options } = instance
+      const tokens = instance.parse('# test')
+
+      instance.renderer.rules.heading_open = () => '['
+      instance.renderer.rules.heading_close = () => ']'
+
+      const rendererOne = instance.IncrementalDOMRenderer
+      IncrementalDOM.patch(document.body, rendererOne.render(tokens, options))
+      assert(document.body.innerHTML === '[test]')
+
+      instance.renderer.rules.heading_open = () => '^'
+      instance.renderer.rules.heading_close = () => '$'
+
+      const rendererTwo = instance.IncrementalDOMRenderer
+      IncrementalDOM.patch(document.body, rendererTwo.render(tokens, options))
+      assert(document.body.innerHTML === '^test$')
+    })
+  })
+
   describe('.renderToIncrementalDOM', () => {
     it('returns patchable function by specified Incremental DOM', () => {
       const func = md().renderToIncrementalDOM('markdown-it-incremental-dom')


### PR DESCRIPTION
This PR would define a public getter `get IncrementalDOMRenderer` to the injected instance. This getter would inject a mix-in of rendering method by Incremental DOM into the current state of renderer.

*This method is for the expert.* Normally you can use `renderToIncrementalDOM()`. But we think that it is useful if you have to parse Markdown and operate tokens.

```javascript
const md = new MarkdownIt()
const tokens = md.parse('# Hello')

// ...Any operation to tokens...

const patch = md.IncrementalDOMRenderer.render(tokens, md.options)
IncrementalDOM.patch(document.body, patch)
```

### ToDo

* [x] Add document