### PR TITLE
Support inline SVG correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ### Fixed
 
-* Fix format script to work globstar correctly ([#26](https://github.com/yhatt/markdown-it-incremental-dom/pull/26))
 * Fix build entry and module path for browser ([#27](https://github.com/yhatt/markdown-it-incremental-dom/pull/27))
+* Support inline SVG correctly ([#29](https://github.com/yhatt/markdown-it-incremental-dom/pull/29))
+* Fix format script to work globstar correctly ([#26](https://github.com/yhatt/markdown-it-incremental-dom/pull/26))
 
 ## v1.2.0 - 2018-01-15
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-plugin-empower-assert": "^1.3.0",
     "babel-plugin-espower": "3.0.0-beta.1",
     "babel-plugin-istanbul": "^4.1.5",
+    "common-tags": "^1.7.2",
     "coveralls": "^3.0.0",
     "cross-env": "^5.1.3",
     "eslint": "^4.14.0",

--- a/src/mixins/renderer.js
+++ b/src/mixins/renderer.js
@@ -24,7 +24,11 @@ export default function(incrementalDom) {
       ontext: text,
       onclosetag: name => elementClose(sanitizeName(name)),
     },
-    { decodeEntities: true }
+    {
+      decodeEntities: true,
+      lowerCaseAttributeNames: false,
+      lowerCaseTags: false,
+    }
   )
 
   const wrapIncrementalDOM = html =>

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import { stripIndents } from 'common-tags'
 import MarkdownIt from 'markdown-it'
 import MarkdownItFootnote from 'markdown-it-footnote'
 import MarkdownItSub from 'markdown-it-sub'
@@ -113,6 +114,26 @@ describe('Renderer', () => {
       it('renders invalid nesting HTML', () => {
         md({ html: true }).idom('<table>\n<tr\n</table>')
         assert(document.querySelector('table > tr'))
+      })
+
+      it('renders inline SVG', () => {
+        const svg = stripIndents`
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+            <defs>
+              <linearGradient id="gradation" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#f00" />
+                <stop offset="100%" stop-color="#00f" />
+              </linearGradient>
+            </defs>
+            <rect x="0" y="0" width="32" height="32" fill="url(#gradation)" />
+          </svg>
+        `
+
+        md({ html: true }).idom(svg)
+        assert(document.querySelector('svg[xmlns][viewBox="0 0 32 32"]'))
+        assert(document.querySelector('svg > defs > linearGradient#gradation'))
+        assert(document.querySelector('#gradation > stop + stop'))
+        assert(document.querySelector('svg > rect[x][y][width][height][fill]'))
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,6 +779,13 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.16.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
@@ -1177,6 +1184,12 @@ commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+common-tags@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
+  dependencies:
+    babel-runtime "^6.26.0"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3746,7 +3759,7 @@ regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
 
-regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
If you enable HTML, the tag name and attribute names are converted to lower-case by htmlparser2.

But this behavior could not have worked HTML5 inline SVG elements correctly. (e.g. `<linearGradient>`, `<feDropShadow>` and `<svg>` tag's `viewBox` attr)

We can disable this behavior by setting parser option `lowerCaseAttributeNames` and `lowerCaseTags` to `false`.

#### Markdown

```markdown
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
<defs>
<linearGradient id="gradation" x1="0%" y1="0%" x2="100%" y2="100%">
<stop offset="0%" stop-color="#f00" />
<stop offset="100%" stop-color="#00f" />
</linearGradient>
</defs>
<rect x="0" y="0" width="32" height="32" fill="url(#gradation)" />
</svg>
```

#### Rendering with `lowerCaseAttributeNames` and `lowerCaseTags` options

![incorrect](https://user-images.githubusercontent.com/3993388/36216553-825bd9d2-11f2-11e8-945f-5cc355249fd4.png)

#### Rendering with disabling `lowerCase*` options

![correct](https://user-images.githubusercontent.com/3993388/36216643-ae871a62-11f2-11e8-914a-4493e868ee4d.png)

