### PR TITLE
Fix twice element closing by htmlparser2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix twice element closing by htmlparser2 ([#34](https://github.com/yhatt/markdown-it-incremental-dom/pull/34))
+
 ## v2.0.0 - 2018-08-17
 
 ### Breaking

--- a/src/mixins/renderer.js
+++ b/src/mixins/renderer.js
@@ -85,7 +85,6 @@ export default function(incrementalDom) {
             this.renderToken(tokens, i, options, env)()
           }
         })
-        iDOMParser.end()
         iDOMParser.reset()
       }
     },

--- a/src/mixins/renderer.js
+++ b/src/mixins/renderer.js
@@ -1,15 +1,31 @@
 import Parser from 'htmlparser2/lib/Parser'
 
 export default function(incrementalDom) {
-  const {
-    attr,
-    elementClose,
-    elementOpen,
-    elementOpenEnd,
-    elementOpenStart,
-    elementVoid,
-    text,
-  } = incrementalDom
+  const autoClosingStack = []
+
+  const autoClosing = () => {
+    const stack = autoClosingStack.shift()
+    if (!stack) return
+
+    stack.reverse().forEach(tag => incrementalDom.elementClose(tag))
+  }
+
+  const { attr, elementOpenEnd, elementVoid, text } = incrementalDom
+
+  const elementOpen = (tag, ...args) => {
+    if (autoClosingStack.length > 0) autoClosingStack[0].push(tag)
+    incrementalDom.elementOpen(tag, ...args)
+  }
+
+  const elementOpenStart = tag => {
+    if (autoClosingStack.length > 0) autoClosingStack[0].push(tag)
+    incrementalDom.elementOpenStart(tag)
+  }
+
+  const elementClose = tag => {
+    if (autoClosingStack.length > 0) autoClosingStack[0].pop()
+    incrementalDom.elementClose(tag)
+  }
 
   const sanitizeName = name => name.replace(/[^-:\w]/g, '')
 
@@ -42,6 +58,7 @@ export default function(incrementalDom) {
 
     renderInline(tokens, options, env) {
       return () => {
+        autoClosingStack.unshift([])
         tokens.forEach((current, i) => {
           const { type } = current
 
@@ -51,6 +68,7 @@ export default function(incrementalDom) {
             this.renderToken(tokens, i, options)()
           }
         })
+        autoClosing()
       }
     },
 
@@ -74,6 +92,7 @@ export default function(incrementalDom) {
 
     render(tokens, options, env) {
       return () => {
+        autoClosingStack.unshift([])
         tokens.forEach((current, i) => {
           const { type } = current
 
@@ -85,6 +104,7 @@ export default function(incrementalDom) {
             this.renderToken(tokens, i, options, env)()
           }
         })
+        autoClosing()
         iDOMParser.reset()
       }
     },

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -147,6 +147,18 @@ describe('Renderer', () => {
     })
   })
 
+  context('with overriden renderers', () => {
+    context('when HTML parser is used only in opening element', () => {
+      it('renders correctly', () => {
+        const markdown = md()
+        markdown.renderer.rules.paragraph_open = () => '<p class="overriden">'
+        markdown.idom('Render correctly')
+
+        expect(document.querySelector('p.overriden')).toBeTruthy()
+      })
+    })
+  })
+
   context('with other plugins', () => {
     context('when markdown-it-sub is injected (simple plugin)', () => {
       const instance = md().use(MarkdownItSub)


### PR DESCRIPTION
`htmlparser2`'s `end()` will close the still opening elements in buffer. But it would close an element twice when only the opening renderer that is using HTML parser is overriden. It causes raising error by Incremental DOM.

We could fix by simply removing `htmlparser2.end()`.

Fix #33.